### PR TITLE
Add StackedToadz strategy [unstackedtoadz-and-stackedtoadz-stakers]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -201,7 +201,8 @@ import * as agave from './agave';
 import * as juicebox from './juicebox';
 import * as snetFarmers from './snet-farmers';
 import * as snetStakers from './snet-stakers';
-import * as snetLiquidityProviders from "./snet-liquidity-providers"
+import * as snetLiquidityProviders from './snet-liquidity-providers';
+import * as unstackedToadzAndStackedToadzStakers from './unstackedtoadz-and-stackedtoadz-stakers';
 
 const strategies = {
   'nouns-rfp-power': nounsPower,
@@ -405,7 +406,8 @@ const strategies = {
   juicebox,
   'snet-farmers': snetFarmers,
   'snet-stakers': snetStakers,
-  "snet-liquidity-providers": snetLiquidityProviders
+  'snet-liquidity-providers': snetLiquidityProviders,
+  'unstackedtoadz-and-stackedtoadz-stakers': unstackedToadzAndStackedToadzStakers
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/README.md
+++ b/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/README.md
@@ -1,0 +1,32 @@
+# UnstackedToadz and StackedToadz Stakers strategy
+
+This strategy return the balances of the voters for StackedToadz project using only the staking pool of UnstackedToadz and StackedToadz.
+
+## Accepted options
+
+- **staking_stackedtoadz:** StackedToadz staking pool address.
+
+- **staking_unstackedtoadz:** UnStackedToadz staking pool address.
+
+## Examples
+
+```JSON
+[
+  {
+    "name": "UnstackedToadz and StackedToadz Stakers",
+    "strategy": {
+      "name": "unstackedtoadz-and-stackedtoadz-stakers",
+      "params": {
+        "staking_stackedtoadz": "0xBC9d59a9865c094d22fAAE988533F18eA1688722",
+        "staking_unstackedtoadz": "0x1bbb57def2f6192f0b9b8565f49034bf1fcdb604"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x6d330e23da437fb66e8419e8f52fcd43fa6b8326"
+    ],
+    "snapshot": 13688108
+  }
+]
+
+```

--- a/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/examples.json
+++ b/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "UnstackedToadz and StackedToadz Stakers",
+    "strategy": {
+      "name": "unstackedtoadz-and-stackedtoadz-stakers",
+      "params": {
+        "symbol": "STACK",
+        "decimals": 0,
+        "tokenAddress": "0x1bbb57def2f6192f0b9b8565f49034bf1fcdb604",
+        "staking_stackedtoadz": "0xBC9d59a9865c094d22fAAE988533F18eA1688722",
+        "staking_unstackedtoadz": "0x1bbb57def2f6192f0b9b8565f49034bf1fcdb604"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x6d330e23da437fb66e8419e8f52fcd43fa6b8326"
+    ],
+    "snapshot": 13745053
+  }
+]

--- a/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/index.ts
+++ b/src/strategies/unstackedtoadz-and-stackedtoadz-stakers/index.ts
@@ -1,0 +1,58 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+
+export const author = 'Eh_Marine';
+export const version = '0.1.0';
+
+const stakingAbi = [
+  'function depositsOf(address account) external view  returns (uint256[] memory)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stacked_stakingPool = new Multicaller(network, provider, stakingAbi, {
+    blockTag
+  });
+  const unstacked_stakingPool = new Multicaller(network, provider, stakingAbi, {
+    blockTag
+  });
+
+  addresses.forEach((address) => {
+    stacked_stakingPool.call(
+      address,
+      options.staking_stackedtoadz,
+      'depositsOf',
+      [address]
+    );
+    unstacked_stakingPool.call(
+      address,
+      options.staking_unstackedtoadz,
+      'depositsOf',
+      [address]
+    );
+  });
+
+  const [stakingResponse_stacked, stackingResponse_unstacked]: [
+    Record<string, BigNumberish[]>,
+    Record<string, BigNumberish[]>
+  ] = await Promise.all([
+    stacked_stakingPool.execute(),
+    unstacked_stakingPool.execute()
+  ]);
+
+  return Object.fromEntries(
+    addresses.map((address) => {
+      const stakingCount_stacked = stakingResponse_stacked[address].length;
+      const stakingCount_unstacked = stackingResponse_unstacked[address].length;
+      return [address, stakingCount_stacked + stakingCount_unstacked];
+    })
+  );
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Added strategy to account for only StackedToadz and UnstackedToadz stakers for the StackedToadz project which is required for governance voting.
- Voting power determined by (number of StackedToadz staked + number of UnstackedToadz staked).